### PR TITLE
infer.sh: Fix error detection on detect.roboflow.com API endpoint

### DIFF
--- a/infer.sh
+++ b/infer.sh
@@ -356,7 +356,7 @@ if [ ! -z "$verbose" ]; then
     echo "Inference URL: $inference_url"
 fi
 
-if [[ $(curl -s $inference_url | grep -e "not authorized" -e "does not exist") ]]; then
+if [[ $(curl -s $inference_url | grep -e "Forbidden" -e "Not Found") ]]; then
     echo "Invalid API Key or Model ID.";
     exit 1;
 fi


### PR DESCRIPTION
The detect.roboflow.com API endpoint appears to return one of:

- Invalid API key `{"message":"Forbidden"}`

- Invalid model ID `{"detail":"Not Found"}`

- Other invalid parameters (e.g. no POST data given) `{"detail":"Method Not Allowed"}`

Perhaps in the past, it returned "not authorized" and "does not exist", but not anymore.

Without this patch, running infer.sh carries along merrily until it attempts to put together an output video, and shows a bunch of errors like this one, due to the input files just containing one of the JSON errors listed above:

```
[mjpeg @ 0x55c365593fc0] No JPEG data found in image
Error while decoding stream #0:0: Invalid data found when processing input
```

It might be worth setting up some e2e tests that directly hit the API endpoint (or an internal test instance) to prevent this from happening again.